### PR TITLE
Poke controller add regi shiny

### DIFF
--- a/SerialController/Commands/PythonCommands/ImageProcessingOnly/RegiShiny.py
+++ b/SerialController/Commands/PythonCommands/ImageProcessingOnly/RegiShiny.py
@@ -41,7 +41,7 @@ class RegiShiny(ImageProcPythonCommand):
             self.press(Button.X, wait=0.38)
             self.press(Button.A, wait=5)
             self.press(Button.A, wait=1.5)
-            self.press(Button.A, wait=14.)
+            self.press(Button.A, wait=16.)
             self.press(Button.A, wait=5.)
             counter += 1
 

--- a/SerialController/Commands/PythonCommands/ImageProcessingOnly/RegiShiny.py
+++ b/SerialController/Commands/PythonCommands/ImageProcessingOnly/RegiShiny.py
@@ -14,7 +14,7 @@ class RegiSeries(Enum):
 
 class RegiShiny(ImageProcPythonCommand):
     regi_series = None
-    template_file_paths = []
+    template_file_path = ""
 
     def __init__(self, cam):
         super().__init__(cam)
@@ -46,19 +46,16 @@ class RegiShiny(ImageProcPythonCommand):
             counter += 1
 
     def is_shiny(self, counter):
-        index = self.mostSimilarTemplate(self.template_file_paths, show_value=True, use_gray=False)
-        if index == 1:
-            sendToSlack("shiny!")
-            return True
-        print("not shiny")
+        # 通常色である場合にFalseを返す
+        if self.isContainTemplate(self.template_file_path, threshold=0.7, show_value=True, use_gray=False):
+            print("not shiny")
+            return False
         return False
-
-
 
 class RegielekiShiny(RegiShiny):
     NAME = 'レジエレキ/ドラゴ色厳選'
     regi_series = RegiSeries.REGIELEKI
-    template_file_paths = ['regieleki_normal.png', 'regieleki_shiny.png']
+    template_file_path = 'regieleki_normal.png'
     def __init__(self, cam):
         super().__init__(cam)
 


### PR DESCRIPTION
色違いを逃したので判定方法を変更した
色違いの際にnormalの画像のZNCC valueが0.7以下だったのでそれを閾値にして判定するようにした．